### PR TITLE
Add unit tests execution before PyPI deployment

### DIFF
--- a/sunholo/.github/workflows/python-publish.yml
+++ b/sunholo/.github/workflows/python-publish.yml
@@ -1,0 +1,48 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Test minimal install
+      run: |
+        python -m venv venv
+        source venv/bin/activate
+        pip install dist/sunholo*.whl  # Install the built package
+        python -c "import sunholo"  # Test that the package is importable
+        deactivate
+    - name: Run unit tests
+      run: python -m unittest discover tests
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This pull request introduces a crucial update to the GitHub workflow for deploying the package to PyPI, ensuring that unit tests are run before the deployment process.

- **Adds a new step** named "Run unit tests" in the `.github/workflows/python-publish.yml` file, which executes all unit tests in the `tests/` directory using the command `python -m unittest discover tests`.
- **Ensures** that the deployment to PyPI proceeds only if all unit tests pass successfully, enhancing the reliability of the package published.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sunholo-data/sunholo-py?shareId=cd95bfda-942c-4ad7-a2b8-27fba88b64fa).

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2bc3b44705af3895966bd64f7d8a57d9fd4598c0  | 
|--------|--------|

### Summary:
This PR introduces a step to execute unit tests before deploying the package to PyPI, enhancing the reliability of the published package.

**Key points**:
- Adds `Run unit tests` step in `.github/workflows/python-publish.yml`
- Ensures deployment only if tests pass


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
