### PR TITLE
Add unit tests for config functions

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,40 @@
+import pytest
+from sunholo.utils import config
+
+# Test for the `load_config` function
+def test_load_config():
+    # Assuming the function is supposed to load a configuration from a file
+    # and return a dictionary with the configuration data
+    expected_config = {"key": "value"}
+    with pytest.raises(FileNotFoundError):
+        config.load_config("non_existent_file")
+    with pytest.mock.patch("builtins.open", pytest.mock.mock_open(read_data="key: value"), create=True):
+        assert config.load_config("mock_file.yaml") == expected_config
+
+# Test for the `load_config_key` function
+def test_load_config_key():
+    # Assuming the function is supposed to load a specific key from the configuration
+    expected_value = "value"
+    with pytest.raises(KeyError):
+        config.load_config_key("non_existent_key", "mock_vector_name")
+    with pytest.mock.patch("sunholo.utils.config.load_all_configs", return_value={"mock_vector_name": {"key": "value"}}):
+        assert config.load_config_key("key", "mock_vector_name") == expected_value
+
+# Test for the `get_module_filepath` function
+def test_get_module_filepath():
+    # Assuming the function is supposed to return the absolute path of a module file
+    expected_path = "/absolute/path/to/module/file"
+    with pytest.mock.patch("os.path.dirname", return_value="/absolute/path/to"):
+        assert config.get_module_filepath("module/file") == expected_path
+
+# Test for the `fetch_config` function
+def test_fetch_config():
+    # Assuming the function is supposed to fetch configuration from a cloud storage bucket
+    expected_update_time = "2022-01-01T00:00:00Z"
+    with pytest.mock.patch("google.cloud.storage.Client") as mock_client:
+        mock_bucket = mock_client.return_value.get_bucket.return_value
+        mock_blob = mock_bucket.get_blob.return_value
+        mock_blob.updated = expected_update_time
+        assert config.fetch_config("bucket_name", "blob_name") == expected_update_time
+        mock_bucket.get_blob.return_value = None
+        assert config.fetch_config("bucket_name", "blob_name") is None


### PR DESCRIPTION
Adds new unit tests for previously untested functions within the `sunholo.utils.config` module to the `tests/` directory, ensuring comprehensive coverage and organization.

- **Load Config Tests**: Adds tests for the `load_config` function to verify it correctly loads configuration from a file and handles non-existent files by raising a `FileNotFoundError`.
- **Load Config Key Tests**: Implements tests for the `load_config_key` function to ensure it correctly extracts a specific key from the configuration and raises a `KeyError` for non-existent keys.
- **Module Filepath Tests**: Adds tests for the `get_module_filepath` function to confirm it returns the correct absolute path of a module file.
- **Fetch Config Tests**: Introduces tests for the `fetch_config` function to check it fetches configuration from a cloud storage bucket correctly and handles non-existent blobs by returning `None`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sunholo-data/sunholo-py?shareId=4a38f1ae-55e8-47af-b2a9-c8e2280d6df3).