### PR TITLE
Add unit tests for dispatch_to_qa

### DIFF
--- a/tests/test_dispatch_to_qa.py
+++ b/tests/test_dispatch_to_qa.py
@@ -4,7 +4,11 @@ from sunholo.agents.dispatch_to_qa import prep_request_payload
 
 @pytest.mark.parametrize("user_input, chat_history, vector_name, stream, expected_endpoint, expected_payload", [
     ("What is AI?", [], "my_vector", False, "http://example.com/invoke", {"user_input": "What is AI?", "chat_history": [], "vector_name": "my_vector"}),
-    ("Tell me about ML", ["Previous chat message"], "another_vector", True, "http://example.com/stream", {"user_input": "Tell me about ML", "chat_history": ["Previous chat message"], "vector_name": "another_vector"})
+    ("Tell me about ML", ["Previous chat message"], "another_vector", True, "http://example.com/stream", {"user_input": "Tell me about ML", "chat_history": ["Previous chat message"], "vector_name": "another_vector"}),
+    # Additional test cases to cover all logic paths
+    ("", [], "empty_input_vector", False, "http://example.com/invoke", {"user_input": "", "chat_history": [], "vector_name": "empty_input_vector"}),
+    ("Valid input", ["Chat history present"], "history_vector", False, "http://example.com/invoke", {"user_input": "Valid input", "chat_history": ["Chat history present"], "vector_name": "history_vector"}),
+    ("Stream request", [], "stream_vector", True, "http://example.com/stream", {"user_input": "Stream request", "chat_history": [], "vector_name": "stream_vector"})
 ])
 @patch('sunholo.agents.dispatch_to_qa.load_config_key')
 @patch('sunholo.agents.dispatch_to_qa.route_endpoint')


### PR DESCRIPTION
Expands the unit tests for the `prep_request_payload` function in `tests/test_dispatch_to_qa.py` to ensure full coverage of all logic paths.

- Adds new test cases to cover scenarios with empty user input, presence of chat history, and stream requests, ensuring comprehensive testing of the `prep_request_payload` function.
- Utilizes `pytest.mark.parametrize` to efficiently test multiple input combinations and expected outcomes.
- Employs mocking for external calls (`load_config_key` and `route_endpoint`) to maintain test isolation and self-containment.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sunholo-data/sunholo-py?shareId=0c5ac7b7-2643-4c57-85b0-fde55b606d01).