### PR TITLE
Add unit tests for dispatch_to_qa prep_request_payload function

### DIFF
--- a/tests/test_dispatch_to_qa.py
+++ b/tests/test_dispatch_to_qa.py
@@ -8,13 +8,19 @@ from sunholo.agents.dispatch_to_qa import prep_request_payload
     # Additional test cases to cover all logic paths
     ("", [], "empty_input_vector", False, "http://example.com/invoke", {"user_input": "", "chat_history": [], "vector_name": "empty_input_vector"}),
     ("Valid input", ["Chat history present"], "history_vector", False, "http://example.com/invoke", {"user_input": "Valid input", "chat_history": ["Chat history present"], "vector_name": "history_vector"}),
-    ("Stream request", [], "stream_vector", True, "http://example.com/stream", {"user_input": "Stream request", "chat_history": [], "vector_name": "stream_vector"})
+    ("Stream request", [], "stream_vector", True, "http://example.com/stream", {"user_input": "Stream request", "chat_history": [], "vector_name": "stream_vector"}),
+    # New test cases for prep_request_payload function
+    ("User input with override endpoint", [], "override_vector", False, "http://override.com/invoke", {"user_input": "User input with override endpoint", "chat_history": [], "vector_name": "override_vector"}),
+    ("Stream with chat history and override endpoint", ["Chat history for override"], "override_stream_vector", True, "http://override.com/stream", {"user_input": "Stream with chat history and override endpoint", "chat_history": ["Chat history for override"], "vector_name": "override_stream_vector"})
 ])
 @patch('sunholo.agents.dispatch_to_qa.load_config_key')
 @patch('sunholo.agents.dispatch_to_qa.route_endpoint')
 def test_prep_request_payload(mock_route_endpoint, mock_load_config_key, user_input, chat_history, vector_name, stream, expected_endpoint, expected_payload):
     mock_route_endpoint.return_value = {"invoke": "http://example.com/invoke", "stream": "http://example.com/stream"}
     mock_load_config_key.side_effect = lambda key, vector_name=None, kind=None: "my_vector" if key == "vector_name" else None
+    # Mocking for override endpoint scenario
+    if vector_name.startswith("override"):
+        mock_route_endpoint.return_value = {"invoke": "http://override.com/invoke", "stream": "http://override.com/stream"}
 
     endpoint, payload = prep_request_payload(user_input, chat_history, vector_name, stream)
 


### PR DESCRIPTION
Expands the unit tests for the `prep_request_payload` function in `tests/test_dispatch_to_qa.py` to ensure comprehensive coverage and self-containment.
- Adds new test cases to cover scenarios with override endpoints, enhancing the test suite's ability to verify the function's behavior under different configurations.
- Implements mocking for the `route_endpoint` return value to simulate conditions where the endpoint is overridden based on the `vector_name`, ensuring the tests remain isolated from external dependencies.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sunholo-data/sunholo-py?shareId=082b8f1d-22cb-42ad-9ebf-dfc5d01e77a5).
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit efc9d14d98281044ec5c0c0d8551cfcb2b93357c  | 
|--------|--------|

### Summary:
Enhances the unit tests for `prep_request_payload` by adding scenarios with overridden endpoints and implementing necessary mocking.

**Key points**:
- Expanded unit tests for `prep_request_payload` in `tests/test_dispatch_to_qa.py`.
- Added test cases for scenarios with overridden endpoints.
- Implemented mocking for `route_endpoint` to simulate endpoint overrides based on `vector_name`.
- Ensured tests are self-contained and do not rely on external configurations.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->