### PR TITLE
Add unit tests for chunker module functions

### DIFF
--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,23 +1,52 @@
 import pytest
 from unittest.mock import patch, MagicMock
 from sunholo.chunker.data_to_embed_pubsub import data_to_embed_pubsub
+from sunholo.chunker.doc_handling import send_doc_to_docstore, create_big_doc, summarise_docs
+from sunholo.chunker.images import upload_doc_images
 
-# Mock external calls within the function
+# Existing test for data_to_embed_pubsub function
 @patch('sunholo.chunker.data_to_embed_pubsub.process_pubsub_message', return_value=({}, {}, 'test_vector'))
 @patch('sunholo.chunker.data_to_embed_pubsub.process_chunker_data', return_value='processed_data')
 def test_data_to_embed_pubsub(mock_process_chunker_data, mock_process_pubsub_message):
-    # Test the function with various inputs including edge cases
     assert data_to_embed_pubsub({}) == 'processed_data'
     assert data_to_embed_pubsub({'key': 'value'}) == 'processed_data'
     mock_process_pubsub_message.assert_called()
     mock_process_chunker_data.assert_called()
 
-    # Ensure tests are self-contained and do not require external dependencies
-    mock_process_pubsub_message = MagicMock(return_value=({}, {}, 'test_vector'))
-    mock_process_chunker_data = MagicMock(return_value='processed_data')
-    assert data_to_embed_pubsub({'key': 'value'}) == 'processed_data'
+# New tests for send_doc_to_docstore function
+@patch('sunholo.chunker.doc_handling.add_document_if_not_exists', return_value='doc_id')
+def test_send_doc_to_docstore(mock_add_document_if_not_exists):
+    docs = [{'page_content': 'content', 'metadata': {'source': 'test_source'}}]
+    vector_name = 'test_vector'
+    doc_id, processed_docs = send_doc_to_docstore(docs, vector_name)
+    assert doc_id == 'doc_id'
+    assert processed_docs == docs
+    mock_add_document_if_not_exists.assert_called_once()
 
-    # Validate the function's output against expected results
-    expected_output = 'processed_data'
-    actual_output = data_to_embed_pubsub({'key': 'value'})
-    assert actual_output == expected_output, f"Expected {expected_output}, got {actual_output}"
+# New tests for create_big_doc function
+def test_create_big_doc():
+    docs = [{'page_content': 'content1', 'metadata': {'source': 'test_source1'}},
+            {'page_content': 'content2', 'metadata': {'source': 'test_source2'}}]
+    doc_id, big_doc, processed_docs = create_big_doc(docs)
+    assert doc_id is not None
+    assert big_doc.page_content == 'content1\ncontent2'
+    assert len(processed_docs) == 2
+
+# New tests for summarise_docs function
+@patch('sunholo.chunker.doc_handling.llm_str_to_llm', return_value=MagicMock())
+def test_summarise_docs(mock_llm_str_to_llm):
+    docs = [{'page_content': 'content', 'metadata': {'source': 'test_source'}}]
+    vector_name = 'test_vector'
+    summaries = summarise_docs(docs, vector_name)
+    assert len(summaries) == 1
+    mock_llm_str_to_llm.assert_called_once()
+
+# New tests for upload_doc_images function
+@patch('sunholo.chunker.images.add_file_to_gcs', return_value='gs://bucket/image.jpg')
+def test_upload_doc_images(mock_add_file_to_gcs):
+    metadata = {'image_base64': 'base64imagestring', 'vector_name': 'test_vector', 'bucket_name': 'bucket'}
+    gsurl = upload_doc_images(metadata)
+    assert gsurl == 'gs://bucket/image.jpg'
+    assert 'image_base64' not in metadata  # Ensure image_base64 is removed
+    assert metadata['uploaded_to_bucket'] is True
+    mock_add_file_to_gcs.assert_called_once()


### PR DESCRIPTION
Expands the unit tests in `tests/test_chunker.py` to cover additional functions within the `sunholo.chunker` module, ensuring comprehensive testing and self-containment.

- **Adds tests for `send_doc_to_docstore`**: Mocks external calls and verifies the function's ability to process documents and return expected identifiers and processed documents.
- **Introduces tests for `create_big_doc`**: Validates the function's capability to merge document contents and metadata correctly, ensuring the creation of a 'big document' from multiple smaller ones.
- **Implements tests for `summarise_docs`**: Uses mocking to test the summarization logic, checking that summaries are correctly generated for given documents.
- **Adds tests for `upload_doc_images`**: Ensures the function correctly uploads images to a specified bucket and modifies the metadata accordingly, including the removal of the `image_base64` key and setting the `uploaded_to_bucket` flag to true.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sunholo-data/sunholo-py?shareId=027399fd-8a65-4cf6-a5c0-2c760e58dd35).
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e91bcfaec0169d2c7023a8aae33dc78e464a25c6  | 
|--------|--------|

### Summary:
Expands unit tests for the `chunker` module, enhancing test coverage for document processing and handling functions.

**Key points**:
- Adds unit tests in `tests/test_chunker.py` for `send_doc_to_docstore`, `create_big_doc`, `summarise_docs`, and `upload_doc_images`.
- Uses mocking to isolate functions and test functionality effectively.
- Ensures functions handle data correctly and modify metadata as expected.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->