### PR TITLE
Add release skill to project .claude/

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "additionalDirectories": [
+      "/Users/mark/dev/sunholo/blog"
+    ],
+    "allow": [
+      "WebFetch(domain:dev.sunholo.com)"
+    ]
+  }
+}

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: Release
+description: Manage releases for Python projects. Use when user asks to release, bump version, tag, publish to PyPI, or monitor release workflows. Also use for /release.
+---
+
+# Release
+
+Manages the full release lifecycle for sunholo-py and similar Python projects: version bumping, local testing, git tagging, pushing to trigger CI/CD, and monitoring GitHub Actions workflows through to PyPI publication.
+
+## Quick Start
+
+**Most common usage:**
+```
+User: "release a new patch version"
+# This skill will:
+# 1. Read current version from pyproject.toml
+# 2. Bump patch version (e.g., 0.146.1 → 0.146.2)
+# 3. Run local tests (uv run pytest tests)
+# 4. Commit version bump via PR (protected branch)
+# 5. After merge, create annotated git tag v0.146.2
+# 6. Push tag to trigger GitHub Actions
+# 7. Monitor workflow status until PyPI publish completes
+```
+
+## When to Use This Skill
+
+Invoke this skill when:
+- User asks to "release", "publish", "deploy to PyPI", or "tag a release"
+- User says "bump version" (patch/minor/major)
+- User asks to "monitor the release" or "check workflow status"
+- User says "/release"
+- User asks "what version are we on?"
+
+## Available Scripts
+
+### `scripts/bump_version.sh <patch|minor|major>`
+Reads the current version from pyproject.toml and bumps it.
+
+### `scripts/monitor_workflows.sh <tag>`
+Monitors GitHub Actions workflows triggered by a tag push.
+
+### `scripts/check_version.sh`
+Displays the current version from pyproject.toml.
+
+## Workflow
+
+### 1. Pre-Release Checks
+
+Before any release:
+- Ensure you're on the `main` branch (or the branch to release from)
+- Run `scripts/check_version.sh` to see current version
+- Run `uv run pytest tests` to verify all tests pass locally
+- Check `git status` for uncommitted changes
+
+### 2. Version Bump
+
+Run `scripts/bump_version.sh <patch|minor|major>` to update pyproject.toml.
+
+**Version types:**
+- `patch`: 0.146.1 → 0.146.2 (bug fixes, CI fixes)
+- `minor`: 0.146.1 → 0.147.0 (new features, module additions)
+- `major`: 0.146.1 → 1.0.0 (breaking changes)
+
+**Protected branch workflow:**
+Since main is typically protected, the version bump needs a PR:
+1. Create branch: `git checkout -b release/v{new_version}`
+2. Commit the pyproject.toml change
+3. Push and create PR via `gh pr create`
+4. Wait for user to merge (or merge if allowed)
+
+### 3. Tag and Push
+
+After the version bump is merged to main:
+```bash
+git checkout main && git pull origin main
+git tag -a v{version} -m "Release v{version}
+
+- Summary of changes
+- Key features or fixes"
+git push origin v{version}
+```
+
+Tag format: Always `v{version}` (e.g., `v0.146.1`).
+
+### 4. Monitor Workflows
+
+Run `scripts/monitor_workflows.sh v{version}` to watch the three triggered workflows:
+
+| Workflow | File | Purpose |
+|----------|------|---------|
+| Test Python Package | test.yml | Run full test suite |
+| Create GitHub Release | github-release.yml | Create GitHub Release page |
+| Upload Python Package | python-publish.yml | Build, test, publish to PyPI |
+
+The publish workflow steps:
+1. Checkout code
+2. Setup Python
+3. Install build + pytest
+4. `python -m build` (sdist + wheel)
+5. Test minimal install (`pip install dist/*.whl && python -c "import sunholo"`)
+6. Run unit tests (`pip install .[test] && pytest tests`)
+7. Publish via `pypa/gh-action-pypi-publish`
+
+### 5. Handle Failures
+
+If a workflow fails:
+1. Check failure details: `gh run view <run-id> --log-failed`
+2. Common issues:
+   - **Test failures**: Optional deps missing in CI (use `pytest.importorskip`)
+   - **Build failures**: Check pyproject.toml syntax
+   - **Publish failures**: Check PyPI token secret
+3. Fix the issue, bump version again (patch), and re-release
+4. **Never reuse a tag** that was pushed to PyPI (even if it failed partway)
+
+### 6. Verify Publication
+
+After successful workflow:
+```bash
+pip install sunholo=={version}  # Test install from PyPI
+```
+
+## Resources
+
+### Workflow Reference
+See [resources/reference.md](resources/reference.md) for GitHub Actions workflow details, troubleshooting guide, and common failure patterns.
+
+## Notes
+
+- **Always use `uv`** for local package management, never pip directly
+- **Never force-push tags** — create a new patch version instead
+- **Main branch is protected** — version bumps require PRs with approving reviews
+- **CI tests with `.[test]` only** — channel/adk tests must skip when optional deps are missing
+- Repository: `sunholo-data/sunholo-py`
+- PyPI package name: `sunholo`

--- a/.claude/skills/release/resources/reference.md
+++ b/.claude/skills/release/resources/reference.md
@@ -1,0 +1,111 @@
+# Release Skill Reference
+
+## GitHub Actions Workflows
+
+### python-publish.yml (Upload Python Package)
+- **Triggers**: `release: [published]` and `push: tags: ['v*']`
+- **Permissions**: `contents: write`
+- **Steps**:
+  1. `actions/checkout@v3`
+  2. `actions/setup-python@v3` (Python 3.x, currently resolves to 3.14.x)
+  3. Install: `pip install build pytest`
+  4. Build: `python -m build`
+  5. Test minimal install: venv + `pip install dist/*.whl` + `python -c "import sunholo"`
+  6. Run unit tests: `pip install .[test]` then `pytest tests`
+  7. Publish: `pypa/gh-action-pypi-publish` with `PYPI_API_TOKEN` secret
+
+### github-release.yml (Create GitHub Release)
+- **Triggers**: `push: tags: ['v*']`
+- Creates a GitHub Release page from the tag
+
+### test.yml (Test Python Package)
+- Runs the full test suite on push/PR
+
+## Common Failure Patterns
+
+### 1. Missing Optional Dependencies in CI
+**Symptom**: `ImportError: <package> is required for <module>`
+**Cause**: CI installs `pip install .[test]` which doesn't include optional groups like `[channels]`, `[adk]`
+**Fix**: Add `pytest.importorskip("<package>")` at the start of tests that need optional deps
+**Example**:
+```python
+@pytest.mark.asyncio
+async def test_something(self):
+    pytest.importorskip("httpx")
+    from sunholo.channels.telegram import TelegramChannel
+    ...
+```
+
+### 2. Version Already Exists on PyPI
+**Symptom**: `HTTPError: 400 Bad Request - File already exists`
+**Cause**: Attempted to re-upload a version that already exists
+**Fix**: Never reuse versions. Bump to a new patch version.
+
+### 3. Build Failures
+**Symptom**: `python -m build` fails
+**Cause**: Usually pyproject.toml syntax issues
+**Fix**: Test build locally first: `python -m build`
+
+### 4. PyPI Token Issues
+**Symptom**: `403 Forbidden` during publish
+**Cause**: `PYPI_API_TOKEN` secret expired or misconfigured
+**Fix**: Regenerate token on PyPI and update GitHub repository secret
+
+## Version Scheme
+
+Follows semantic versioning: `MAJOR.MINOR.PATCH`
+
+| Change Type | Bump | Example |
+|------------|------|---------|
+| Bug fix, CI fix, typo | patch | 0.146.1 → 0.146.2 |
+| New module, feature | minor | 0.146.1 → 0.147.0 |
+| Breaking API change | major | 0.146.1 → 1.0.0 |
+
+## Tag Format
+
+Always prefix with `v`: `v0.146.1`
+
+Annotated tags with release notes:
+```bash
+git tag -a v0.146.1 -m "Release v0.146.1
+
+- Fix CI: skip channel tests when httpx unavailable
+- Bump setuptools requirement"
+```
+
+## Protected Branch Workflow
+
+Since `main` is protected (requires PR with approving review):
+
+1. Create release branch: `git checkout -b release/v0.146.1`
+2. Make changes (version bump, fixes)
+3. Commit and push
+4. Create PR: `gh pr create --title "Release v0.146.1" --body "..."`
+5. Wait for approval and merge
+6. Switch to main: `git checkout main && git pull`
+7. Tag: `git tag -a v0.146.1 -m "Release v0.146.1"`
+8. Push tag: `git push origin v0.146.1`
+
+## Dependency Groups
+
+The `pyproject.toml` defines these optional dependency groups:
+
+| Group | Key Packages | CI Installed |
+|-------|-------------|-------------|
+| `test` | pytest, pytest-asyncio | Yes |
+| `channels` | httpx, twilio, markdown | No |
+| `adk` | google-adk, litellm | No |
+| `gcp` | google-cloud-* | No |
+| `all` | Everything | No |
+
+Tests for optional-dep modules MUST use `pytest.importorskip()` to gracefully skip in CI.
+
+## Checklist
+
+Before releasing:
+- [ ] All local tests pass (`uv run pytest tests`)
+- [ ] Version bumped in pyproject.toml
+- [ ] No uncommitted changes
+- [ ] On main branch (for tagging)
+- [ ] Previous release workflow succeeded (check PyPI)
+- [ ] Tag doesn't already exist

--- a/.claude/skills/release/scripts/bump_version.sh
+++ b/.claude/skills/release/scripts/bump_version.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Bump version in pyproject.toml
+# Usage: bump_version.sh <patch|minor|major> [path/to/pyproject.toml]
+#
+# Examples:
+#   bump_version.sh patch   # 0.146.1 → 0.146.2
+#   bump_version.sh minor   # 0.146.1 → 0.147.0
+#   bump_version.sh major   # 0.146.1 → 1.0.0
+
+set -euo pipefail
+
+BUMP_TYPE="${1:-}"
+PYPROJECT="${2:-pyproject.toml}"
+
+if [ -z "$BUMP_TYPE" ]; then
+    echo "Usage: bump_version.sh <patch|minor|major> [pyproject.toml]" >&2
+    exit 1
+fi
+
+if [ ! -f "$PYPROJECT" ]; then
+    echo "ERROR: $PYPROJECT not found" >&2
+    exit 1
+fi
+
+# Parse current version
+CURRENT=$(grep '^version = ' "$PYPROJECT" | head -1 | sed 's/version = "\(.*\)"/\1/')
+if [ -z "$CURRENT" ]; then
+    echo "ERROR: Could not parse version from $PYPROJECT" >&2
+    exit 1
+fi
+
+# Split into components
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+# Bump
+case "$BUMP_TYPE" in
+    patch)
+        PATCH=$((PATCH + 1))
+        ;;
+    minor)
+        MINOR=$((MINOR + 1))
+        PATCH=0
+        ;;
+    major)
+        MAJOR=$((MAJOR + 1))
+        MINOR=0
+        PATCH=0
+        ;;
+    *)
+        echo "ERROR: Invalid bump type '$BUMP_TYPE'. Use: patch, minor, or major" >&2
+        exit 1
+        ;;
+esac
+
+NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+# Update pyproject.toml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/^version = \"${CURRENT}\"/version = \"${NEW_VERSION}\"/" "$PYPROJECT"
+else
+    sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW_VERSION}\"/" "$PYPROJECT"
+fi
+
+# Verify
+VERIFY=$(grep '^version = ' "$PYPROJECT" | head -1 | sed 's/version = "\(.*\)"/\1/')
+if [ "$VERIFY" != "$NEW_VERSION" ]; then
+    echo "ERROR: Version update failed. Expected $NEW_VERSION, got $VERIFY" >&2
+    exit 1
+fi
+
+echo "Version bumped: $CURRENT → $NEW_VERSION"
+echo "Tag will be: v$NEW_VERSION"
+echo ""
+echo "Next steps:"
+echo "  1. Run tests: uv run pytest tests"
+echo "  2. Commit: git add pyproject.toml && git commit -m 'Bump version to $NEW_VERSION'"
+echo "  3. If main is protected, create a PR"
+echo "  4. After merge, tag: git tag -a v$NEW_VERSION -m 'Release v$NEW_VERSION'"
+echo "  5. Push tag: git push origin v$NEW_VERSION"

--- a/.claude/skills/release/scripts/check_version.sh
+++ b/.claude/skills/release/scripts/check_version.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Check current version from pyproject.toml
+# Usage: check_version.sh [path/to/pyproject.toml]
+
+set -euo pipefail
+
+PYPROJECT="${1:-pyproject.toml}"
+
+if [ ! -f "$PYPROJECT" ]; then
+    echo "ERROR: $PYPROJECT not found" >&2
+    echo "Run from the project root directory." >&2
+    exit 1
+fi
+
+VERSION=$(grep '^version = ' "$PYPROJECT" | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+if [ -z "$VERSION" ]; then
+    echo "ERROR: Could not parse version from $PYPROJECT" >&2
+    exit 1
+fi
+
+echo "Current version: $VERSION"
+echo "Tag would be: v$VERSION"
+
+# Check if tag already exists
+if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
+    echo "WARNING: Tag v$VERSION already exists!"
+    echo "Latest tags:"
+    git tag --sort=-v:refname | head -5
+else
+    echo "Tag v$VERSION does not exist yet (ready to tag)"
+fi
+
+# Show latest tags for context
+echo ""
+echo "Recent tags:"
+git tag --sort=-v:refname | head -5 2>/dev/null || echo "(no tags found)"

--- a/.claude/skills/release/scripts/monitor_workflows.sh
+++ b/.claude/skills/release/scripts/monitor_workflows.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Monitor GitHub Actions workflows triggered by a tag push
+# Usage: monitor_workflows.sh <tag> [--wait]
+#
+# Examples:
+#   monitor_workflows.sh v0.146.1          # Check status once
+#   monitor_workflows.sh v0.146.1 --wait   # Poll until all complete
+
+set -euo pipefail
+
+TAG="${1:-}"
+WAIT="${2:-}"
+
+if [ -z "$TAG" ]; then
+    echo "Usage: monitor_workflows.sh <tag> [--wait]" >&2
+    echo "Example: monitor_workflows.sh v0.146.1" >&2
+    exit 1
+fi
+
+# Verify gh CLI is available
+if ! command -v gh &> /dev/null; then
+    echo "ERROR: gh CLI not found. Install from https://cli.github.com/" >&2
+    exit 1
+fi
+
+echo "Monitoring workflows for tag: $TAG"
+echo "================================================"
+
+check_workflows() {
+    local all_complete=true
+    local any_failed=false
+
+    # List workflow runs triggered by this tag
+    RUNS=$(gh run list --limit 10 --json "workflowName,status,conclusion,databaseId,event,headBranch" 2>/dev/null)
+
+    if [ -z "$RUNS" ] || [ "$RUNS" = "[]" ]; then
+        echo "No workflow runs found yet. They may take a moment to start."
+        all_complete=false
+        return 1
+    fi
+
+    # Filter runs related to this tag (headBranch matches tag name without 'v' prefix sometimes)
+    echo ""
+    echo "Workflow Status ($(date '+%H:%M:%S')):"
+    echo "----------------------------------------"
+
+    # Use jq to process
+    echo "$RUNS" | jq -r '.[] | "\(.workflowName)|\(.status)|\(.conclusion // "pending")|\(.databaseId)"' | while IFS='|' read -r name status conclusion run_id; do
+        # Status emoji
+        case "$status" in
+            completed)
+                case "$conclusion" in
+                    success) icon="PASS" ;;
+                    failure) icon="FAIL" ;;
+                    cancelled) icon="SKIP" ;;
+                    *) icon="?   " ;;
+                esac
+                ;;
+            in_progress) icon="... " ;;
+            queued) icon="WAIT" ;;
+            *) icon="?   " ;;
+        esac
+        printf "  [%s] %-30s (run %s)\n" "$icon" "$name" "$run_id"
+    done
+
+    # Check if all are complete
+    INCOMPLETE=$(echo "$RUNS" | jq '[.[] | select(.status != "completed")] | length')
+    FAILED=$(echo "$RUNS" | jq '[.[] | select(.conclusion == "failure")] | length')
+
+    echo ""
+    if [ "$INCOMPLETE" -gt 0 ]; then
+        echo "Status: $INCOMPLETE workflow(s) still running..."
+        return 1
+    elif [ "$FAILED" -gt 0 ]; then
+        echo "Status: $FAILED workflow(s) FAILED"
+        echo ""
+        echo "To view failure details:"
+        echo "$RUNS" | jq -r '.[] | select(.conclusion == "failure") | "  gh run view \(.databaseId) --log-failed"'
+        return 2
+    else
+        echo "Status: All workflows completed successfully!"
+        return 0
+    fi
+}
+
+if [ "$WAIT" = "--wait" ]; then
+    echo "Polling every 30s until all workflows complete..."
+    while true; do
+        check_workflows
+        result=$?
+        if [ $result -eq 0 ]; then
+            echo ""
+            echo "All done! Verify on PyPI:"
+            VERSION="${TAG#v}"
+            echo "  pip install sunholo==$VERSION"
+            break
+        elif [ $result -eq 2 ]; then
+            echo ""
+            echo "Fix failures and re-release with a new patch version."
+            exit 1
+        fi
+        echo ""
+        echo "Waiting 30s before next check..."
+        sleep 30
+    done
+else
+    check_workflows
+    exit $?
+fi


### PR DESCRIPTION
## Summary
- Move release skill from global `~/.claude/skills/` to project-level `.claude/skills/` so it's scoped to this repo (the only one publishing to PyPI)
- Add shared `.claude/settings.json` for project permissions

## Test plan
- [x] Verified skill still appears in active skills list after move
- [x] No sensitive data in committed files (`settings.local.json` excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)